### PR TITLE
- enhancement/#41

### DIFF
--- a/controllers/ItemsController.php
+++ b/controllers/ItemsController.php
@@ -255,7 +255,7 @@
 
 		public function Edit($request = null)
 		{
-			$lists = $departments = false;
+			$lists = $packsizes = $departments = false;
 
 			$item = $this->items_service->verifyItemRequest(['item_id' => $request]);
 

--- a/dal/PackSizesDAL.php
+++ b/dal/PackSizesDAL.php
@@ -20,7 +20,7 @@
 
 			try
 			{
-				$query = $this->ShopDb->conn->prepare("SELECT id AS packsize_id, name AS packsize_name, short_name AS packsize_short_name FROM pack_sizes");
+				$query = $this->ShopDb->conn->prepare("SELECT id AS packsize_id, name AS packsize_name, short_name AS packsize_short_name FROM pack_sizes ORDER BY packsize_name");
 				$query->execute();
 				$rows = $query->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
- add 'ORDER BY' clause to PackSizesDAL::getAllPackSizes()
- find & fix PHP notice caused by undefined variable 'packsizes' if manually navigating to /items/edit/{id}/ for an invalid ItemID